### PR TITLE
Correct the directory for storing phaser.d.ts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   npm i --save phaser
 ```
 
-3. Copy `phaser.d.ts` from `/node_modules/phaser/types/` and place it in your project's `src/` folder.  
+3. Copy `phaser.d.ts` from `/node_modules/phaser/types/` and place it in your project folder.  
 4. Copy `phaser.min.js` from `/node_modules/phaser/dist/` and place it in your project's `src/assets/` folder.
 5. Add reference to the `phaser.min.js` file in your `index.html`.
 ```


### PR DESCRIPTION
Hi Braelyn,

I followed your article at https://medium.com/@braelynnn/using-phaser-in-an-angular-8-component-53644a2280e3 to integrate Phaser with Angular TypeScript. It is very helpful, thank you for sharing.

However both the article and the README.md mentions copying phaser.d.ts to the "src" directory, while the correct directory should be the project directory - I figured this out by exploring this github project.

Hence I have this CL to fix it, please take a look.

m.t.
